### PR TITLE
feat(frontend): bootstrap discovery-driven explorer

### DIFF
--- a/apps/frontend/src/components/EndpointExplorer.vue
+++ b/apps/frontend/src/components/EndpointExplorer.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue';
+import { computed, onMounted, reactive, ref, watch } from 'vue';
+import { fetchManifest } from '../discovery/client';
+import type { ExplorerEndpoint, ExplorerEntityType, ExplorerManifest } from '../discovery/types';
 
-type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+type HttpMethod = ExplorerEndpoint['method'];
 
 type ExplorerState = {
   method: HttpMethod;
@@ -17,9 +19,19 @@ type ExplorerState = {
   error?: string;
 };
 
+type NavigationSelection =
+  | { type: 'module'; module: 'fields' | 'datatypes'; endpoint: ExplorerEndpoint }
+  | { type: 'entity'; entity: ExplorerEntityType; endpoint: ExplorerEndpoint };
+
 const apiBaseUrl = computed(
   () => import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, '') || 'http://localhost:3000'
 );
+
+const manifest = ref<ExplorerManifest>();
+const manifestError = ref<string>();
+const isLoadingManifest = ref(false);
+
+const selectedNavigation = ref<NavigationSelection>();
 
 const state = reactive<ExplorerState>({
   method: 'GET',
@@ -29,6 +41,100 @@ const state = reactive<ExplorerState>({
 });
 
 const requestBodyIsJson = ref(true);
+
+const buildEndpointKey = (selection: NavigationSelection) => {
+  if (selection.type === 'module') {
+    return `${selection.module}:${selection.endpoint.method}:${selection.endpoint.path}`;
+  }
+  return `entity:${selection.entity.key}:${selection.endpoint.method}:${selection.endpoint.path}`;
+};
+
+const selectedEndpointKey = computed(() =>
+  selectedNavigation.value ? buildEndpointKey(selectedNavigation.value) : undefined
+);
+
+const defaultBodyForMethod = (method: HttpMethod) => {
+  if (method === 'GET' || method === 'DELETE') {
+    return '';
+  }
+  return '{}';
+};
+
+const stringifyBody = (payload: unknown) => JSON.stringify(payload, null, 2);
+
+const applySelection = (selection: NavigationSelection) => {
+  selectedNavigation.value = selection;
+  state.method = selection.endpoint.method;
+  state.path = selection.endpoint.path;
+
+  let nextBody = defaultBodyForMethod(selection.endpoint.method);
+
+  if (selection.type === 'entity') {
+    const examples = selection.entity.examples;
+    if (selection.endpoint.method === 'POST') {
+      if (selection.endpoint.name.toLowerCase() === 'create' && examples?.create) {
+        nextBody = stringifyBody(examples.create);
+      } else if (selection.endpoint.name.toLowerCase() === 'update' && examples?.update) {
+        nextBody = stringifyBody(examples.update);
+      }
+    }
+    if (
+      selection.endpoint.method === 'GET' &&
+      selection.endpoint.name.toLowerCase() === 'list' &&
+      examples?.listQuery
+    ) {
+      nextBody = stringifyBody(examples.listQuery);
+    }
+  }
+
+  state.requestBody = nextBody;
+  state.response = undefined;
+  state.error = undefined;
+};
+
+const selectDefaultEndpoint = (loadedManifest: ExplorerManifest) => {
+  const entity = loadedManifest.modules.entities.types[0];
+  if (entity?.routes[0]) {
+    applySelection({ type: 'entity', entity, endpoint: entity.routes[0] });
+    return;
+  }
+
+  const fieldsEndpoint = loadedManifest.modules.fields.endpoints[0];
+  if (fieldsEndpoint) {
+    applySelection({ type: 'module', module: 'fields', endpoint: fieldsEndpoint });
+    return;
+  }
+
+  const datatypeEndpoint = loadedManifest.modules.datatypes.endpoints[0];
+  if (datatypeEndpoint) {
+    applySelection({ type: 'module', module: 'datatypes', endpoint: datatypeEndpoint });
+  }
+};
+
+const loadManifest = async () => {
+  isLoadingManifest.value = true;
+  manifestError.value = undefined;
+
+  try {
+    const data = await fetchManifest(apiBaseUrl.value);
+    manifest.value = data;
+    selectDefaultEndpoint(data);
+  } catch (error) {
+    manifestError.value = error instanceof Error ? error.message : 'Failed to load manifest.';
+    manifest.value = undefined;
+  } finally {
+    isLoadingManifest.value = false;
+  }
+};
+
+onMounted(() => {
+  void loadManifest();
+});
+
+watch(apiBaseUrl, () => {
+  // When the base URL changes (e.g. environment switch), refresh the manifest.
+  void loadManifest();
+});
 
 const submit = async () => {
   state.isLoading = true;
@@ -88,16 +194,118 @@ const submit = async () => {
 };
 
 const reset = () => {
-  state.method = 'GET';
-  state.path = '/api/health';
-  state.requestBody = '{\n  "example": true\n}';
-  state.response = undefined;
-  state.error = undefined;
+  if (selectedNavigation.value) {
+    applySelection(selectedNavigation.value);
+  } else {
+    state.method = 'GET';
+    state.path = '/api/health';
+    state.requestBody = '{\n  "example": true\n}';
+    state.response = undefined;
+    state.error = undefined;
+  }
 };
+
+const manifestBaseUrl = computed(() =>
+  manifest.value ? `${apiBaseUrl.value}${manifest.value.baseUrl}` : apiBaseUrl.value
+);
 </script>
 
 <template>
   <section class="explorer">
+    <aside class="explorer__nav" aria-label="API navigation">
+      <header class="explorer__nav-header">
+        <h2>Available endpoints</h2>
+        <button class="explorer__refresh" type="button" @click="loadManifest" :disabled="isLoadingManifest">
+          {{ isLoadingManifest ? 'Refreshing…' : 'Refresh' }}
+        </button>
+      </header>
+
+      <p v-if="isLoadingManifest" class="explorer__hint">Loading discovery manifest…</p>
+      <p v-else-if="manifestError" class="explorer__error">{{ manifestError }}</p>
+
+      <template v-else-if="manifest">
+        <section class="explorer__nav-group">
+          <h3>Fields</h3>
+          <ul>
+            <li
+              v-for="endpoint in manifest.modules.fields.endpoints"
+              :key="`fields:${endpoint.method}:${endpoint.path}`"
+            >
+              <button
+                type="button"
+                class="explorer__nav-item"
+                :class="{
+                  'explorer__nav-item--active':
+                    selectedEndpointKey === `fields:${endpoint.method}:${endpoint.path}`
+                }"
+                @click="applySelection({ type: 'module', module: 'fields', endpoint })"
+              >
+                <span class="explorer__nav-method">{{ endpoint.method }}</span>
+                <span class="explorer__nav-label">{{ endpoint.name }}</span>
+                <span class="explorer__nav-path">{{ endpoint.path }}</span>
+              </button>
+            </li>
+          </ul>
+        </section>
+
+        <section class="explorer__nav-group">
+          <h3>Datatypes</h3>
+          <ul>
+            <li
+              v-for="endpoint in manifest.modules.datatypes.endpoints"
+              :key="`datatypes:${endpoint.method}:${endpoint.path}`"
+            >
+              <button
+                type="button"
+                class="explorer__nav-item"
+                :class="{
+                  'explorer__nav-item--active':
+                    selectedEndpointKey === `datatypes:${endpoint.method}:${endpoint.path}`
+                }"
+                @click="applySelection({ type: 'module', module: 'datatypes', endpoint })"
+              >
+                <span class="explorer__nav-method">{{ endpoint.method }}</span>
+                <span class="explorer__nav-label">{{ endpoint.name }}</span>
+                <span class="explorer__nav-path">{{ endpoint.path }}</span>
+              </button>
+            </li>
+          </ul>
+        </section>
+
+        <section class="explorer__nav-group">
+          <h3>Entities</h3>
+          <div
+            v-for="entity in manifest.modules.entities.types"
+            :key="entity.key"
+            class="explorer__entity"
+          >
+            <h4 class="explorer__entity-title">{{ entity.label }}</h4>
+            <ul>
+              <li
+                v-for="endpoint in entity.routes"
+                :key="`entity:${entity.key}:${endpoint.method}:${endpoint.path}`"
+              >
+                <button
+                  type="button"
+                  class="explorer__nav-item"
+                  :class="{
+                    'explorer__nav-item--active':
+                      selectedEndpointKey ===
+                      `entity:${entity.key}:${endpoint.method}:${endpoint.path}`
+                  }"
+                  @click="applySelection({ type: 'entity', entity, endpoint })"
+                >
+                  <span class="explorer__nav-method">{{ endpoint.method }}</span>
+                  <span class="explorer__nav-label">{{ endpoint.name }}</span>
+                  <span class="explorer__nav-path">{{ endpoint.path }}</span>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </section>
+      </template>
+    </aside>
+
     <form class="explorer__form" @submit.prevent="submit">
       <div class="explorer__row">
         <label class="explorer__label" for="method">Method</label>
@@ -122,7 +330,7 @@ const reset = () => {
       </div>
 
       <div class="explorer__row">
-        <label class="explorer__label" for="body">Request body</label>
+        <label class="explorer__label" for="body">Request body / params</label>
         <textarea
           id="body"
           v-model="state.requestBody"
@@ -147,7 +355,7 @@ const reset = () => {
       <div class="explorer__response-header">
         <div>
           <h2>Response</h2>
-          <p class="explorer__hint">Base URL: {{ apiBaseUrl }}</p>
+          <p class="explorer__hint">Base URL: {{ manifestBaseUrl }}</p>
         </div>
         <p v-if="state.response" class="explorer__status">
           {{ state.response.status }} {{ state.response.statusText }}
@@ -175,12 +383,19 @@ const reset = () => {
 
 <style scoped>
 .explorer {
-  width: min(100%, 1080px);
+  width: min(100%, 1240px);
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: minmax(240px, 280px) repeat(2, minmax(280px, 1fr));
 }
 
+@media (max-width: 960px) {
+  .explorer {
+    grid-template-columns: 1fr;
+  }
+}
+
+.explorer__nav,
 .explorer__form,
 .explorer__response {
   background: rgba(15, 23, 42, 0.7);
@@ -189,6 +404,114 @@ const reset = () => {
   padding: 1.5rem;
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
   backdrop-filter: blur(12px);
+}
+
+.explorer__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.explorer__nav-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.explorer__refresh {
+  font: inherit;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: transparent;
+  color: #e2e8f0;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.explorer__refresh:hover,
+.explorer__refresh:focus-visible {
+  outline: none;
+  border-color: #38bdf8;
+  background: rgba(30, 64, 175, 0.35);
+}
+
+.explorer__nav-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.explorer__nav-group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.explorer__entity {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.explorer__entity-title {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #cbd5f5;
+}
+
+.explorer__nav-item {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5rem 0.75rem;
+  align-items: center;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  background: rgba(30, 41, 59, 0.65);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.explorer__nav-item:hover,
+.explorer__nav-item:focus-visible {
+  outline: none;
+  border-color: rgba(148, 163, 184, 0.7);
+  background: rgba(30, 64, 175, 0.45);
+}
+
+.explorer__nav-item--active {
+  border-color: #38bdf8;
+  background: rgba(30, 64, 175, 0.6);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.explorer__nav-method {
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.2);
+  color: #bae6fd;
+}
+
+.explorer__nav-label {
+  font-weight: 600;
+}
+
+.explorer__nav-path {
+  grid-column: 1 / -1;
+  font-size: 0.75rem;
+  color: #94a3b8;
 }
 
 .explorer__row {

--- a/apps/frontend/src/discovery/client.ts
+++ b/apps/frontend/src/discovery/client.ts
@@ -1,0 +1,48 @@
+import type { EntitySchemaResponse, ExplorerManifest } from './types';
+
+const normalizeBaseUrl = (baseUrl: string) => baseUrl.replace(/\/$/, '');
+
+const buildUrl = (baseUrl: string, path: string) =>
+  `${normalizeBaseUrl(baseUrl)}${path.startsWith('/') ? '' : '/'}${path}`;
+
+const handleResponse = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    let message = `Request failed with status ${response.status}`;
+    try {
+      const payload = await response.json();
+      if (typeof payload?.message === 'string') {
+        message = payload.message;
+      }
+    } catch {
+      // ignore json parse errors
+    }
+    throw new Error(message);
+  }
+
+  return (await response.json()) as T;
+};
+
+export const fetchManifest = async (baseUrl: string): Promise<ExplorerManifest> => {
+  const url = buildUrl(baseUrl, '/api/discovery/manifest');
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/json'
+    }
+  });
+
+  return handleResponse<ExplorerManifest>(response);
+};
+
+export const fetchEntitySchema = async (
+  baseUrl: string,
+  entityKey: string
+): Promise<EntitySchemaResponse> => {
+  const url = buildUrl(baseUrl, `/api/discovery/entities/${encodeURIComponent(entityKey)}/schema`);
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/json'
+    }
+  });
+
+  return handleResponse<EntitySchemaResponse>(response);
+};

--- a/apps/frontend/src/discovery/client.ts
+++ b/apps/frontend/src/discovery/client.ts
@@ -5,12 +5,15 @@ const normalizeBaseUrl = (baseUrl: string) => baseUrl.replace(/\/$/, '');
 const buildUrl = (baseUrl: string, path: string) =>
   `${normalizeBaseUrl(baseUrl)}${path.startsWith('/') ? '' : '/'}${path}`;
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
 const handleResponse = async <T>(response: Response): Promise<T> => {
   if (!response.ok) {
     let message = `Request failed with status ${response.status}`;
     try {
-      const payload = await response.json();
-      if (typeof payload?.message === 'string') {
+      const payload: unknown = await response.json();
+      if (isRecord(payload) && typeof payload.message === 'string') {
         message = payload.message;
       }
     } catch {
@@ -19,15 +22,18 @@ const handleResponse = async <T>(response: Response): Promise<T> => {
     throw new Error(message);
   }
 
-  return (await response.json()) as T;
+  const data: unknown = await response.json();
+  return data as T;
 };
 
-export const fetchManifest = async (baseUrl: string): Promise<ExplorerManifest> => {
+export const fetchManifest = async (
+  baseUrl: string,
+): Promise<ExplorerManifest> => {
   const url = buildUrl(baseUrl, '/api/discovery/manifest');
   const response = await fetch(url, {
     headers: {
-      Accept: 'application/json'
-    }
+      Accept: 'application/json',
+    },
   });
 
   return handleResponse<ExplorerManifest>(response);
@@ -35,13 +41,16 @@ export const fetchManifest = async (baseUrl: string): Promise<ExplorerManifest> 
 
 export const fetchEntitySchema = async (
   baseUrl: string,
-  entityKey: string
+  entityKey: string,
 ): Promise<EntitySchemaResponse> => {
-  const url = buildUrl(baseUrl, `/api/discovery/entities/${encodeURIComponent(entityKey)}/schema`);
+  const url = buildUrl(
+    baseUrl,
+    `/api/discovery/entities/${encodeURIComponent(entityKey)}/schema`,
+  );
   const response = await fetch(url, {
     headers: {
-      Accept: 'application/json'
-    }
+      Accept: 'application/json',
+    },
   });
 
   return handleResponse<EntitySchemaResponse>(response);

--- a/apps/frontend/src/discovery/types.ts
+++ b/apps/frontend/src/discovery/types.ts
@@ -1,0 +1,116 @@
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export type JsonPrimitive = string | number | boolean | null;
+
+interface JsonSchemaBase {
+  $schema?:
+    | 'http://json-schema.org/draft-07/schema#'
+    | 'https://json-schema.org/draft/2020-12/schema';
+  title?: string;
+  description?: string;
+}
+
+export interface JsonSchemaString extends JsonSchemaBase {
+  type: 'string';
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  format?: 'date-time' | 'date' | 'time' | 'email' | 'uuid' | 'uri';
+  enum?: string[];
+  'x-unique'?: boolean;
+  'x-caseInsensitive'?: boolean;
+}
+
+export interface JsonSchemaNumber extends JsonSchemaBase {
+  type: 'number' | 'integer';
+  minimum?: number;
+  maximum?: number;
+  multipleOf?: number;
+  'x-unique'?: boolean;
+}
+
+export interface JsonSchemaBoolean extends JsonSchemaBase {
+  type: 'boolean';
+  'x-unique'?: boolean;
+}
+
+export interface JsonSchemaArray extends JsonSchemaBase {
+  type: 'array';
+  items: JsonSchema;
+  minItems?: number;
+  maxItems?: number;
+}
+
+export interface JsonSchemaObject extends JsonSchemaBase {
+  type: 'object';
+  properties: Record<string, JsonSchema>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+export type JsonSchema =
+  | JsonSchemaString
+  | JsonSchemaNumber
+  | JsonSchemaBoolean
+  | JsonSchemaArray
+  | JsonSchemaObject;
+
+export interface ExplorerEndpoint {
+  name: string;
+  method: HttpMethod;
+  path: string;
+  requestSchema?: JsonSchema;
+  responseSchema?: JsonSchema;
+  requestSchemaRef?: string;
+  responseSchemaRef?: string;
+}
+
+export interface EntitySchemas {
+  create: JsonSchemaObject;
+  update: JsonSchemaObject;
+  listQuery: JsonSchemaObject;
+  entityResponse: JsonSchemaObject;
+}
+
+export interface EntityExamples {
+  create?: Record<string, JsonPrimitive | JsonPrimitive[]>;
+  update?: Record<string, JsonPrimitive | JsonPrimitive[]>;
+  listQuery?: Record<string, string | number | boolean>;
+}
+
+export interface ExplorerEntityType {
+  key: string;
+  label: string;
+  storage: 'single' | 'perType';
+  routes: ExplorerEndpoint[];
+  schemas: EntitySchemas;
+  examples?: EntityExamples;
+}
+
+export interface ExplorerModulesManifest {
+  fields: {
+    endpoints: ExplorerEndpoint[];
+  };
+  datatypes: {
+    endpoints: ExplorerEndpoint[];
+  };
+  entities: {
+    types: ExplorerEntityType[];
+  };
+}
+
+export interface ExplorerManifest {
+  version: 1;
+  baseUrl: string;
+  openapiUrl: string;
+  modules: ExplorerModulesManifest;
+  generatedAt: string;
+}
+
+export interface EntitySchemaResponse {
+  key: string;
+  label: string;
+  storage: 'single' | 'perType';
+  routes: ExplorerEndpoint[];
+  schemas: EntitySchemas;
+}

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -7,6 +7,9 @@
     "paths": {
       "@/*": ["./src/*"]
     },
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "declarationDir": "./node_modules/.tmp/types",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "jsx": "preserve"
   },


### PR DESCRIPTION
## Summary
- add a lightweight discovery client and shared manifest typings for the frontend
- drive the API explorer UI from the discovery manifest with navigation across modules and entities
- tune the frontend TypeScript config for bundler-compatible builds

## Testing
- pnpm --filter frontend build

------
https://chatgpt.com/codex/tasks/task_e_68e56315f00c832f9996aa5d1b927dcb