### PR TITLE
refactor(fields): move seed json into data folder

### DIFF
--- a/src/Data/fields.seeds.json
+++ b/src/Data/fields.seeds.json
@@ -1,0 +1,7 @@
+[
+  { "key": "string", "label": "String", "kind": { "type": "string" } },
+  { "key": "number", "label": "Number", "kind": { "type": "number" } },
+  { "key": "boolean", "label": "Boolean", "kind": { "type": "boolean" } },
+  { "key": "date", "label": "Date", "kind": { "type": "date" } },
+  { "key": "enum", "label": "Enum", "kind": { "type": "enum" } }
+]

--- a/src/modules/fields/internal/fields.seeds.ts
+++ b/src/modules/fields/internal/fields.seeds.ts
@@ -1,15 +1,7 @@
 import type { FieldKind } from '@lib/fields';
-import { isKebabCaseKey, normalizeKeyLower } from '@lib/fields';
+import { isFieldKind, isKebabCaseKey, normalizeKeyLower } from '@lib/fields';
 
-import rawSeedData from '../../../Data/fields.seeds.json' assert { type: 'json' };
-
-function isFieldKindLiteral(value: unknown): value is FieldKind {
-  return (
-    value !== null &&
-    typeof value === 'object' &&
-    typeof (value as FieldKind).type === 'string'
-  );
-}
+import rawSeedData from '../../../Data/fields.seeds.json';
 
 /**
  * Shape of a field seed document before insertion.
@@ -51,10 +43,8 @@ function coerceSeedLiterals(data: unknown): ReadonlyArray<FieldSeedLiteral> {
       throw new Error(`Field seed "${key}" is missing a string "label".`);
     }
 
-    if (!isFieldKindLiteral(kind)) {
-      throw new Error(
-        `Field seed "${key}" must declare a "kind" with a "type".`,
-      );
+    if (!isFieldKind(kind)) {
+      throw new Error(`Field seed "${key}" must declare a valid "kind" shape.`);
     }
 
     return Object.freeze({

--- a/src/modules/fields/internal/fields.seeds.ts
+++ b/src/modules/fields/internal/fields.seeds.ts
@@ -1,6 +1,16 @@
 import type { FieldKind } from '@lib/fields';
 import { isKebabCaseKey, normalizeKeyLower } from '@lib/fields';
 
+import rawSeedData from '../../../Data/fields.seeds.json' assert { type: 'json' };
+
+function isFieldKindLiteral(value: unknown): value is FieldKind {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as FieldKind).type === 'string'
+  );
+}
+
 /**
  * Shape of a field seed document before insertion.
  * (No _id / timestamps; those are assigned by the bootstrap when syncing.)
@@ -13,16 +23,52 @@ export interface FieldSeed {
   readonly locked: true;
 }
 
+type FieldSeedLiteral = Readonly<{
+  key: string;
+  label: string;
+  kind: FieldKind;
+}>;
+
+function coerceSeedLiterals(data: unknown): ReadonlyArray<FieldSeedLiteral> {
+  if (!Array.isArray(data)) {
+    throw new Error('Field seed JSON must be an array.');
+  }
+
+  return data.map((entry, index) => {
+    if (entry === null || typeof entry !== 'object') {
+      throw new Error(`Field seed at index ${index} must be an object.`);
+    }
+
+    const { key, label, kind } = entry as Partial<FieldSeedLiteral>;
+
+    if (typeof key !== 'string' || key.length === 0) {
+      throw new Error(
+        `Field seed at index ${index} is missing a string "key".`,
+      );
+    }
+
+    if (typeof label !== 'string' || label.length === 0) {
+      throw new Error(`Field seed "${key}" is missing a string "label".`);
+    }
+
+    if (!isFieldKindLiteral(kind)) {
+      throw new Error(
+        `Field seed "${key}" must declare a "kind" with a "type".`,
+      );
+    }
+
+    return Object.freeze({
+      key,
+      label,
+      kind,
+    }) as FieldSeedLiteral;
+  });
+}
+
 /** Define the canonical baseline seed list (Stage 1). */
-const BASE_SEEDS: ReadonlyArray<Pick<FieldSeed, 'key' | 'label' | 'kind'>> =
-  Object.freeze([
-    { key: 'string', label: 'String', kind: { type: 'string' } },
-    { key: 'number', label: 'Number', kind: { type: 'number' } },
-    { key: 'boolean', label: 'Boolean', kind: { type: 'boolean' } },
-    { key: 'date', label: 'Date', kind: { type: 'date' } },
-    // Enum allowed without concrete values at seed time; user-defined enums will add constraints.
-    { key: 'enum', label: 'Enum', kind: { type: 'enum' } },
-  ]);
+const BASE_SEEDS: ReadonlyArray<FieldSeedLiteral> = Object.freeze(
+  coerceSeedLiterals(rawSeedData),
+);
 
 /**
  * Built and validated seed documents.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "nodenext",
     "moduleResolution": "nodenext",
+    "resolveJsonModule": true,
     "resolvePackageJsonExports": true,
     "esModuleInterop": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary
- relocate the field seed JSON into src/Data so new entries can be added without touching code
- adjust the TypeScript loader to read from the new location and harden the kind validation helper

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e674047b9c832f926c19178743f8f8