### PR TITLE
feat: seed post datatype

### DIFF
--- a/src/Data/datatypes.seeds.json
+++ b/src/Data/datatypes.seeds.json
@@ -1,0 +1,24 @@
+[
+  {
+    "key": "post",
+    "label": "Post",
+    "status": "published",
+    "storage": { "mode": "single" },
+    "fields": [
+      {
+        "fieldKey": "title",
+        "required": true,
+        "array": false,
+        "unique": false,
+        "order": 0
+      },
+      {
+        "fieldKey": "content",
+        "required": true,
+        "array": false,
+        "unique": false,
+        "order": 1
+      }
+    ]
+  }
+]

--- a/src/Data/fields.seeds.json
+++ b/src/Data/fields.seeds.json
@@ -3,5 +3,21 @@
   { "key": "number", "label": "Number", "kind": { "type": "number" } },
   { "key": "boolean", "label": "Boolean", "kind": { "type": "boolean" } },
   { "key": "date", "label": "Date", "kind": { "type": "date" } },
-  { "key": "enum", "label": "Enum", "kind": { "type": "enum" } }
+  { "key": "enum", "label": "Enum", "kind": { "type": "enum" } },
+  {
+    "key": "title",
+    "label": "Title",
+    "kind": {
+      "type": "string",
+      "constraints": { "minLength": 1, "maxLength": 160 }
+    }
+  },
+  {
+    "key": "content",
+    "label": "Content",
+    "kind": {
+      "type": "string",
+      "constraints": { "minLength": 1 }
+    }
+  }
 ]

--- a/src/modules/datatypes/bootstrap/datatypes.bootstrap.ts
+++ b/src/modules/datatypes/bootstrap/datatypes.bootstrap.ts
@@ -1,0 +1,155 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import type { Collection, Document, WithId } from 'mongodb';
+
+import { MongoActionError } from '../../../lib/errors/MongoActionError';
+import { MongodbService } from '../../mongodb/mongodb.service';
+import {
+  DATATYPES_COLLECTION,
+  type DataTypeDocBase,
+  type EntityField,
+  type EntityIndexSpec,
+} from '../internal';
+import {
+  DATATYPE_SEEDS,
+  type DatatypeSeed,
+  isDatatypeSeedKey,
+} from '../internal';
+
+/**
+ * Seed & index bootstrap for the `datatypes` collection.
+ * - Ensures a unique index on `keyLower`.
+ * - Inserts or reconciles baseline datatype definitions (locked).
+ * - Skips automatically on CI (CI=true/1) or when disabled via env.
+ */
+@Injectable()
+export class DatatypesBootstrap implements OnModuleInit {
+  private readonly logger = new Logger(DatatypesBootstrap.name);
+
+  constructor(private readonly mongo: MongodbService) {}
+
+  public async onModuleInit(): Promise<void> {
+    if (!shouldRunBootstrap()) {
+      this.logger.log('Skipping datatypes bootstrap (CI or disabled by env).');
+      return;
+    }
+
+    try {
+      const coll = await this.getDatatypesCollection();
+      await this.ensureIndexes(coll);
+      await this.syncSeeds(coll);
+      this.logger.log('Datatypes bootstrap complete.');
+    } catch (err) {
+      throw MongoActionError.wrap(err, { operation: 'datatypesBootstrap' });
+    }
+  }
+
+  private async getDatatypesCollection(): Promise<Collection<DataTypeDocBase>> {
+    const db = await this.mongo.getDb();
+    return db.collection<DataTypeDocBase>(DATATYPES_COLLECTION);
+  }
+
+  private async ensureIndexes(coll: Collection<DataTypeDocBase>): Promise<void> {
+    await coll.createIndex(
+      { keyLower: 1 },
+      { unique: true, name: 'uniq_datatypes_keyLower' },
+    );
+  }
+
+  private async syncSeeds(coll: Collection<DataTypeDocBase>): Promise<void> {
+    const now = new Date();
+
+    for (const seed of DATATYPE_SEEDS) {
+      const existing = await coll.findOne({
+        keyLower: seed.keyLower,
+      } as Document);
+
+      if (!existing) {
+        await coll.insertOne(this.buildSeedDoc(seed, now));
+        this.logger.log(`Inserted seed datatype: ${seed.key}`);
+        continue;
+      }
+
+      await coll.updateOne(
+        { _id: (existing as WithId<DataTypeDocBase>)._id } as Document,
+        {
+          $set: this.buildSeedUpdate(seed, now),
+        } as Document,
+      );
+      this.logger.log(`Reconciled seed datatype: ${seed.key}`);
+    }
+
+    const locked = await coll
+      .find({ locked: true } as Document, { projection: { key: 1, _id: 0 } })
+      .toArray();
+
+    for (const doc of locked) {
+      const key = (doc as { key?: unknown }).key;
+      if (typeof key === 'string' && !isDatatypeSeedKey(key)) {
+        this.logger.warn(
+          `Locked datatype not in seed set: "${key}" (left untouched).`,
+        );
+      }
+    }
+  }
+
+  private buildSeedDoc(seed: DatatypeSeed, now: Date): DataTypeDocBase {
+    return {
+      key: seed.key,
+      keyLower: seed.keyLower,
+      label: seed.label,
+      version: seed.version,
+      status: seed.status,
+      fields: this.cloneFields(seed.fields),
+      storage: { mode: seed.storage.mode },
+      indexes: this.cloneIndexes(seed.indexes),
+      locked: true,
+      createdAt: now,
+      updatedAt: now,
+    } satisfies DataTypeDocBase;
+  }
+
+  private buildSeedUpdate(
+    seed: DatatypeSeed,
+    now: Date,
+  ): Partial<DataTypeDocBase> {
+    const update: Partial<DataTypeDocBase> = {
+      label: seed.label,
+      version: seed.version,
+      status: seed.status,
+      fields: this.cloneFields(seed.fields),
+      storage: { mode: seed.storage.mode },
+      indexes: this.cloneIndexes(seed.indexes),
+      locked: true,
+      updatedAt: now,
+    };
+
+    return update;
+  }
+
+  private cloneFields(fields: DatatypeSeed['fields']): EntityField[] {
+    return fields.map((f) => ({
+      fieldKey: f.fieldKey,
+      required: f.required ?? false,
+      array: f.array ?? false,
+      unique: f.unique === true ? true : undefined,
+      constraints: f.constraints ? { ...f.constraints } : undefined,
+      order: f.order,
+    }));
+  }
+
+  private cloneIndexes(
+    indexes: ReadonlyArray<EntityIndexSpec>,
+  ): EntityIndexSpec[] {
+    return indexes.map((idx) => ({
+      keys: { ...idx.keys },
+      options: idx.options ? { ...idx.options } : undefined,
+    }));
+  }
+}
+
+function shouldRunBootstrap(): boolean {
+  const ci = String(process.env.CI ?? '').toLowerCase();
+  if (ci === 'true' || ci === '1') return false;
+  const flag = String(process.env.DATATYPES_BOOTSTRAP ?? '1');
+  return flag !== '0' && flag.toLowerCase() !== 'false';
+}

--- a/src/modules/datatypes/bootstrap/datatypes.bootstrap.ts
+++ b/src/modules/datatypes/bootstrap/datatypes.bootstrap.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import type { Collection, Document, WithId } from 'mongodb';
+import type { Collection, Document } from 'mongodb';
 
 import { MongoActionError } from '../../../lib/errors/MongoActionError';
 import { MongodbService } from '../../mongodb/mongodb.service';
@@ -48,7 +48,9 @@ export class DatatypesBootstrap implements OnModuleInit {
     return db.collection<DataTypeDocBase>(DATATYPES_COLLECTION);
   }
 
-  private async ensureIndexes(coll: Collection<DataTypeDocBase>): Promise<void> {
+  private async ensureIndexes(
+    coll: Collection<DataTypeDocBase>,
+  ): Promise<void> {
     await coll.createIndex(
       { keyLower: 1 },
       { unique: true, name: 'uniq_datatypes_keyLower' },
@@ -70,7 +72,7 @@ export class DatatypesBootstrap implements OnModuleInit {
       }
 
       await coll.updateOne(
-        { _id: (existing as WithId<DataTypeDocBase>)._id } as Document,
+        { _id: existing._id } as Document,
         {
           $set: this.buildSeedUpdate(seed, now),
         } as Document,

--- a/src/modules/datatypes/datatypes.module.ts
+++ b/src/modules/datatypes/datatypes.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { DatatypesService } from './datatypes.service';
 import { DatatypesController } from './datatypes.controller';
 import { MongodbModule } from '../mongodb/mongodb.module';
+import { DatatypesBootstrap } from './bootstrap/datatypes.bootstrap';
 
 @Module({
   imports: [MongodbModule],
   controllers: [DatatypesController],
-  providers: [DatatypesService],
+  providers: [DatatypesService, DatatypesBootstrap],
   exports: [DatatypesService],
 })
 export class DatatypesModule {}

--- a/src/modules/datatypes/internal/datatypes.seeds.ts
+++ b/src/modules/datatypes/internal/datatypes.seeds.ts
@@ -1,17 +1,12 @@
 import { isKebabCaseKey, normalizeKeyLower } from '@lib/fields';
-import type {
-  EntityField,
-  EntityIndexSpec,
-  StorageMode,
-} from '@lib/datatypes';
+import type { EntityField, EntityIndexSpec, StorageMode } from '@lib/datatypes';
 
 import rawSeedData from '../../../Data/datatypes.seeds.json';
 
-export interface DatatypeSeedField
-  extends Pick<
-    EntityField,
-    'fieldKey' | 'required' | 'array' | 'unique' | 'constraints' | 'order'
-  > {}
+export type DatatypeSeedField = Pick<
+  EntityField,
+  'fieldKey' | 'required' | 'array' | 'unique' | 'constraints' | 'order'
+>;
 
 export interface DatatypeSeed {
   readonly key: string;
@@ -51,7 +46,10 @@ type DatatypeSeedLiteral = Readonly<{
   >;
 }>;
 
-function assertPlainObject(value: unknown, context: string): asserts value is PlainObject {
+function assertPlainObject(
+  value: unknown,
+  context: string,
+): asserts value is PlainObject {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error(`${context} must be a plain object.`);
   }
@@ -142,8 +140,7 @@ function coerceSeedLiterals(data: unknown): ReadonlyArray<DatatypeSeedLiteral> {
         });
       });
 
-    const version =
-      literal.version === undefined ? 1 : Number(literal.version);
+    const version = literal.version === undefined ? 1 : Number(literal.version);
     if (!Number.isInteger(version) || version < 1) {
       throw new Error(
         `Datatype seed "${literal.key}" must have an integer version >= 1.`,

--- a/src/modules/datatypes/internal/datatypes.seeds.ts
+++ b/src/modules/datatypes/internal/datatypes.seeds.ts
@@ -1,0 +1,227 @@
+import { isKebabCaseKey, normalizeKeyLower } from '@lib/fields';
+import type {
+  EntityField,
+  EntityIndexSpec,
+  StorageMode,
+} from '@lib/datatypes';
+
+import rawSeedData from '../../../Data/datatypes.seeds.json';
+
+export interface DatatypeSeedField
+  extends Pick<
+    EntityField,
+    'fieldKey' | 'required' | 'array' | 'unique' | 'constraints' | 'order'
+  > {}
+
+export interface DatatypeSeed {
+  readonly key: string;
+  readonly keyLower: string;
+  readonly label: string;
+  readonly version: number;
+  readonly status: 'draft' | 'published';
+  readonly storage: { readonly mode: StorageMode };
+  readonly fields: ReadonlyArray<DatatypeSeedField>;
+  readonly indexes: ReadonlyArray<EntityIndexSpec>;
+  readonly locked: true;
+}
+
+type PlainObject = Readonly<Record<string, unknown>>;
+
+type DatatypeSeedFieldLiteral = Readonly<{
+  fieldKey: string;
+  required?: boolean;
+  array?: boolean;
+  unique?: boolean;
+  constraints?: PlainObject;
+  order?: number;
+}>;
+
+type DatatypeSeedLiteral = Readonly<{
+  key: string;
+  label: string;
+  version?: number;
+  status?: 'draft' | 'published';
+  storage?: Readonly<{ mode?: StorageMode }>;
+  fields: ReadonlyArray<DatatypeSeedFieldLiteral>;
+  indexes?: ReadonlyArray<
+    Readonly<{
+      keys: Readonly<Record<string, 1 | -1 | 'text'>>;
+      options?: PlainObject;
+    }>
+  >;
+}>;
+
+function assertPlainObject(value: unknown, context: string): asserts value is PlainObject {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${context} must be a plain object.`);
+  }
+}
+
+function coerceSeedLiterals(data: unknown): ReadonlyArray<DatatypeSeedLiteral> {
+  if (!Array.isArray(data)) {
+    throw new Error('Datatype seed JSON must be an array.');
+  }
+
+  return data.map((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`Datatype seed at index ${index} must be an object.`);
+    }
+
+    const literal = entry as Partial<DatatypeSeedLiteral>;
+    if (typeof literal.key !== 'string' || literal.key.length === 0) {
+      throw new Error(
+        `Datatype seed at index ${index} is missing a string "key".`,
+      );
+    }
+
+    if (typeof literal.label !== 'string' || literal.label.length === 0) {
+      throw new Error(
+        `Datatype seed "${literal.key}" is missing a string "label".`,
+      );
+    }
+
+    if (!Array.isArray(literal.fields)) {
+      throw new Error(
+        `Datatype seed "${literal.key}" must declare a "fields" array.`,
+      );
+    }
+
+    const fields: DatatypeSeedLiteral['fields'] = literal.fields.map(
+      (field, fieldIndex) => {
+        if (!field || typeof field !== 'object' || Array.isArray(field)) {
+          throw new Error(
+            `Field at index ${fieldIndex} for seed "${literal.key}" must be an object.`,
+          );
+        }
+        const f = field as DatatypeSeedFieldLiteral;
+        if (typeof f.fieldKey !== 'string' || f.fieldKey.length === 0) {
+          throw new Error(
+            `Field at index ${fieldIndex} for seed "${literal.key}" is missing a string "fieldKey".`,
+          );
+        }
+        if (f.constraints !== undefined) {
+          assertPlainObject(
+            f.constraints,
+            `Field constraints for "${literal.key}"`,
+          );
+        }
+        if (f.order !== undefined && typeof f.order !== 'number') {
+          throw new Error(
+            `Field "${f.fieldKey}" on seed "${literal.key}" must have a numeric "order" if provided.`,
+          );
+        }
+        return Object.freeze({ ...f });
+      },
+    );
+
+    const indexes: DatatypeSeedLiteral['indexes'] | undefined =
+      literal.indexes?.map((idx, idxIndex) => {
+        if (!idx || typeof idx !== 'object' || Array.isArray(idx)) {
+          throw new Error(
+            `Index at index ${idxIndex} for seed "${literal.key}" must be an object.`,
+          );
+        }
+        const spec = idx as {
+          keys?: Record<string, 1 | -1 | 'text'>;
+          options?: PlainObject;
+        };
+        if (!spec.keys || typeof spec.keys !== 'object') {
+          throw new Error(
+            `Index spec ${idxIndex} for seed "${literal.key}" must define "keys".`,
+          );
+        }
+        if (spec.options !== undefined) {
+          assertPlainObject(
+            spec.options,
+            `Index options for seed "${literal.key}"`,
+          );
+        }
+        return Object.freeze({
+          keys: { ...spec.keys },
+          options: spec.options ? { ...spec.options } : undefined,
+        });
+      });
+
+    const version =
+      literal.version === undefined ? 1 : Number(literal.version);
+    if (!Number.isInteger(version) || version < 1) {
+      throw new Error(
+        `Datatype seed "${literal.key}" must have an integer version >= 1.`,
+      );
+    }
+
+    const status = literal.status ?? 'draft';
+    if (status !== 'draft' && status !== 'published') {
+      throw new Error(
+        `Datatype seed "${literal.key}" has invalid status "${String(status)}".`,
+      );
+    }
+
+    const storageMode = literal.storage?.mode ?? 'single';
+    if (storageMode !== 'single' && storageMode !== 'perType') {
+      throw new Error(
+        `Datatype seed "${literal.key}" has invalid storage mode "${String(storageMode)}".`,
+      );
+    }
+
+    return Object.freeze({
+      key: literal.key,
+      label: literal.label,
+      version,
+      status,
+      storage: { mode: storageMode },
+      fields,
+      indexes,
+    });
+  });
+}
+
+const BASE_SEEDS: ReadonlyArray<DatatypeSeedLiteral> = Object.freeze(
+  coerceSeedLiterals(rawSeedData),
+);
+
+export const DATATYPE_SEEDS: ReadonlyArray<DatatypeSeed> = Object.freeze(
+  BASE_SEEDS.map((seed) => {
+    const key = seed.key;
+    if (!isKebabCaseKey(key)) {
+      throw new Error(`Invalid datatype seed key (must be kebab-case): ${key}`);
+    }
+
+    const fields = Object.freeze(
+      seed.fields.map((f, index) => ({
+        fieldKey: f.fieldKey,
+        required: f.required ?? false,
+        array: f.array ?? false,
+        unique: f.unique === true ? true : undefined,
+        constraints: f.constraints ? { ...f.constraints } : undefined,
+        order: f.order !== undefined ? f.order : index,
+      })),
+    ) as ReadonlyArray<DatatypeSeedField>;
+
+    const indexes = Object.freeze(
+      (seed.indexes ?? []).map((idx) => ({
+        keys: { ...idx.keys },
+        options: idx.options ? { ...idx.options } : undefined,
+      })),
+    ) as ReadonlyArray<EntityIndexSpec>;
+
+    const normalized: DatatypeSeed = {
+      key,
+      keyLower: normalizeKeyLower(key),
+      label: seed.label,
+      version: seed.version,
+      status: seed.status,
+      storage: { mode: seed.storage.mode },
+      fields,
+      indexes,
+      locked: true,
+    };
+
+    return Object.freeze(normalized);
+  }),
+);
+
+export function isDatatypeSeedKey(key: string): boolean {
+  const lower = normalizeKeyLower(key);
+  return DATATYPE_SEEDS.some((s) => s.keyLower === lower);
+}

--- a/src/modules/datatypes/internal/datatypes.seeds.ts
+++ b/src/modules/datatypes/internal/datatypes.seeds.ts
@@ -46,6 +46,21 @@ type DatatypeSeedLiteral = Readonly<{
   >;
 }>;
 
+type NormalizedDatatypeSeedLiteral = Readonly<{
+  key: string;
+  label: string;
+  version: number;
+  status: 'draft' | 'published';
+  storage: Readonly<{ mode: StorageMode }>;
+  fields: ReadonlyArray<DatatypeSeedFieldLiteral>;
+  indexes: ReadonlyArray<
+    Readonly<{
+      keys: Readonly<Record<string, 1 | -1 | 'text'>>;
+      options?: PlainObject;
+    }>
+  >;
+}>;
+
 function assertPlainObject(
   value: unknown,
   context: string,
@@ -55,7 +70,9 @@ function assertPlainObject(
   }
 }
 
-function coerceSeedLiterals(data: unknown): ReadonlyArray<DatatypeSeedLiteral> {
+function coerceSeedLiterals(
+  data: unknown,
+): ReadonlyArray<NormalizedDatatypeSeedLiteral> {
   if (!Array.isArray(data)) {
     throw new Error('Datatype seed JSON must be an array.');
   }
@@ -166,14 +183,16 @@ function coerceSeedLiterals(data: unknown): ReadonlyArray<DatatypeSeedLiteral> {
       label: literal.label,
       version,
       status,
-      storage: { mode: storageMode },
+      storage: Object.freeze({ mode: storageMode }),
       fields,
-      indexes,
+      indexes: Object.freeze(
+        indexes ?? [],
+      ) as NormalizedDatatypeSeedLiteral['indexes'],
     });
   });
 }
 
-const BASE_SEEDS: ReadonlyArray<DatatypeSeedLiteral> = Object.freeze(
+const BASE_SEEDS: ReadonlyArray<NormalizedDatatypeSeedLiteral> = Object.freeze(
   coerceSeedLiterals(rawSeedData),
 );
 

--- a/src/modules/datatypes/internal/index.ts
+++ b/src/modules/datatypes/internal/index.ts
@@ -1,1 +1,2 @@
 export * from '@lib/datatypes';
+export * from './datatypes.seeds';


### PR DESCRIPTION
## Summary
- add seeded field definitions for `title` and `content`
- introduce datatype seed plumbing and bootstrap for locked baseline docs
- seed a published `post` datatype composed of the new string fields

## Testing
- pnpm test datatypes

------
https://chatgpt.com/codex/tasks/task_e_68e6a14cda34832f985a0f5aabf720fd